### PR TITLE
Update `package` examples to be valid

### DIFF
--- a/src/options.nix
+++ b/src/options.nix
@@ -22,7 +22,7 @@ in {
     packages = mkOption {
       type = listOf package;
       default = [];
-      example = [ "flathub:org.kde.index//stable" "flathub-beta:org.kde.kdenlive//stable" ];
+      example = [ "flathub:app/org.kde.index//stable" "flathub-beta:app/org.kde.kdenlive/x86_64/stable" ];
       description = mdDoc ''
         Which packages to install.
 


### PR DESCRIPTION
The previous examples would fail the validation, so I took these from the docs:

https://github.com/GermanBread/declarative-flatpak/blob/dev/docs/definition.md