### PR TITLE
Fix internet connectivity test on non NixOS systems

### DIFF
--- a/src/script.nix
+++ b/src/script.nix
@@ -2,7 +2,7 @@
 , is-system-install, extra-flatpak-flags ? [] }:
 
 let
-  inherit (pkgs) curl coreutils util-linux inetutils gnugrep flatpak gawk rsync ostree systemd findutils gnused diffutils writeShellScript writeText;
+  inherit (pkgs) curl coreutils util-linux gnugrep flatpak gawk rsync ostree systemd findutils gnused diffutils writeShellScript writeText;
   inherit (lib) makeBinPath;
 
   inherit (import ./lib/regexes.nix) fcommit fref ffile fremote ftype farch fbranch;
@@ -18,7 +18,7 @@ writeShellScript "setup-flatpaks" ''
   set -v
   '' else ""}
   
-  PATH=${makeBinPath [ curl coreutils util-linux inetutils gnugrep flatpak gawk rsync ostree systemd findutils gnused diffutils ]}
+  PATH=${makeBinPath [ curl coreutils util-linux gnugrep flatpak gawk rsync ostree systemd findutils gnused diffutils ]}
   
   ${if cfg.waitForInternet then ''
   # Failsafe

--- a/src/script.nix
+++ b/src/script.nix
@@ -2,7 +2,7 @@
 , is-system-install, extra-flatpak-flags ? [] }:
 
 let
-  inherit (pkgs) coreutils util-linux inetutils gnugrep flatpak gawk rsync ostree systemd findutils gnused diffutils writeShellScript writeText;
+  inherit (pkgs) curl coreutils util-linux inetutils gnugrep flatpak gawk rsync ostree systemd findutils gnused diffutils writeShellScript writeText;
   inherit (lib) makeBinPath;
 
   inherit (import ./lib/regexes.nix) fcommit fref ffile fremote ftype farch fbranch;
@@ -18,12 +18,12 @@ writeShellScript "setup-flatpaks" ''
   set -v
   '' else ""}
   
-  PATH=${makeBinPath [ coreutils util-linux inetutils gnugrep flatpak gawk rsync ostree systemd findutils gnused diffutils ]}
+  PATH=${makeBinPath [ curl coreutils util-linux inetutils gnugrep flatpak gawk rsync ostree systemd findutils gnused diffutils ]}
   
   ${if cfg.waitForInternet then ''
   # Failsafe
   _count=0
-  until ping -c1 github.com &>/dev/null; do
+  until curl -fsS github.com &>/dev/null; do
     if [ $_count -ge 60 ]; then
       echo "failed to acquire an internet connection in 60 seconds."
       exit 1


### PR DESCRIPTION
This fixes #35 by replacing ping with curl for internet functionality tests since ping throws a permissions error. 