### PR TITLE
fix: flake input ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Flakes
 ```nix
 {
   inputs = {
-    flatpaks.url = "github:in-a-dil-emma/declarative-flatpak/latest";
+    flatpaks.url = "github:in-a-dil-emma/declarative-flatpak/v3.1.0";
   };
 }
 ```


### PR DESCRIPTION
Currently, the flake input is broken because `latest` doesn't exist

Note that currently also, this repository has tags, but they are not released, and none is marked as latest : https://github.com/in-a-dil-emma/declarative-flatpak/releases but it still wouldn't change much

https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases

https://github.com/gmodena/nix-flatpak have a valid `latest` ref because they have a [`latest` tag](https://github.com/gmodena/nix-flatpak/releases/tag/latest) which is [updated each time a new semver tag is pushed to point to the same ref](https://github.com/gmodena/nix-flatpak/blob/main/.github/workflows/tag-latest.yml) : https://github.com/gmodena/nix-flatpak/tags; but this is a sub-optimal server-side workaround

Coincidentally, I was also actively trying to find a solution so Nix inputs could make it so it could target the latest released tag / published semver tag instead: [NixOS - Discourse : "How to make a flake input point to the latest release?"](https://discourse.nixos.org/t/how-to-make-a-flake-input-point-to-the-latest-release/69383?u=malix)
I hardly recommend you bookmark this thread, and maybe we could find a solution together