### PR TITLE
add default flake modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Flakes
 ```nix
 { flatpaks, ... }: {
   imports = [
-    flatpaks.nixosModule
+    flatpaks.nixosModules.default
   ];
 }
 ```
@@ -79,7 +79,7 @@ Flakes
 ```nix
 { flatpaks, ... }: {
   imports = [
-    flatpaks.homeModule
+    flatpaks.homeModules.default
   ];
 }
 ```

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,15 @@
   outputs =
     { self }:
     {
-      nixosModule = ./nixos;
-      homeModule = ./home-manager;
+      nixosModule = builtins.warn "declarative-flatpak: flake output `nixosModule` has been renamed to `nixosModules`" ./nixos;
+      homeModule = builtins.warn "declarative-flatpak: flake output `homeModule` has been renamed to `homeModules`" ./home-manager;
+      nixosModules = {
+        default = self.outputs.nixosModules.declarative-flatpak;
+        declarative-flatpak = ./nixos;
+      };
+      homeModules = {
+        default = self.outputs.homeModules.declarative-flatpak;
+        declarative-flatpak = ./home-manager;
+      };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,8 @@
   outputs =
     { self }:
     {
-      nixosModule = builtins.warn "declarative-flatpak: flake output `nixosModule` has been renamed to `nixosModules`" ./nixos;
-      homeModule = builtins.warn "declarative-flatpak: flake output `homeModule` has been renamed to `homeModules`" ./home-manager;
+      nixosModule = builtins.warn "declarative-flatpak: flake output `nixosModule` has been renamed to `nixosModules.default`" ./nixos;
+      homeModule = builtins.warn "declarative-flatpak: flake output `homeModule` has been renamed to `homeModules.default`" ./home-manager;
       nixosModules = {
         default = self.outputs.nixosModules.declarative-flatpak;
         declarative-flatpak = ./nixos;


### PR DESCRIPTION
Singular flake outputs like `nixosModule` has been deprecated for quite some time:

- https://github.com/NixOS/nix/issues/5532

This restructures the flake outputs to follow the current standard convention. The older attributes are still kept for backwards compatibility, but they now print a warning message when used.