### PR TITLE
Update tmpfiles.rules to tmpfiles.settings

### DIFF
--- a/home-manager/service.nix
+++ b/home-manager/service.nix
@@ -40,9 +40,6 @@ in
     tmpfiles.settings = {
       "flatpak-directory".rules."${cfg.internal.targetDir}".d = {
         mode = "750";
-        user = "-";
-        group = "-";
-        age = "-";
       };
     };
     services."manage-flatpaks-activation" =

--- a/home-manager/service.nix
+++ b/home-manager/service.nix
@@ -37,9 +37,14 @@ in
 
 {
   config.systemd.user = {
-    tmpfiles.rules = [
-      "d ${cfg.internal.targetDir} 750 - - - -"
-    ];
+    tmpfiles.settings = {
+      "what-do-i-name-this?".rules."${cfg.internal.targetDir}".d = {
+        mode = "750";
+        user = "-";
+        group = "-";
+        age = "-";
+      };
+    };
     services."manage-flatpaks-activation" =
       pipe
         {

--- a/home-manager/service.nix
+++ b/home-manager/service.nix
@@ -38,7 +38,7 @@ in
 {
   config.systemd.user = {
     tmpfiles.settings = {
-      "what-do-i-name-this?".rules."${cfg.internal.targetDir}".d = {
+      "flatpak-directory".rules."${cfg.internal.targetDir}".d = {
         mode = "750";
         user = "-";
         group = "-";

--- a/nixos/service.nix
+++ b/nixos/service.nix
@@ -1,5 +1,8 @@
-{ config, lib, ... }:
-
+{
+  config,
+  lib,
+  ...
+}:
 let
   inherit (lib) mkIf pipe recursiveUpdate;
   cfg = config.services.flatpak;
@@ -41,12 +44,16 @@ let
       };
     } prev;
 in
-
 {
   config.systemd = {
-    tmpfiles.rules = [
-      "d ${cfg.internal.targetDir} 750 root users - -"
-    ];
+    tmpfiles.settings = {
+      "what-do-i-name-this?".rules."${cfg.internal.targetDir}".d = {
+        mode = "750";
+        user = "-";
+        group = "-";
+        age = "-";
+      };
+    };
     services."manage-flatpaks-activation" =
       pipe
         {

--- a/nixos/service.nix
+++ b/nixos/service.nix
@@ -49,6 +49,8 @@ in
     tmpfiles.settings = {
       "flatpak-directory".rules."${cfg.internal.targetDir}".d = {
         mode = "750";
+        user = "root";
+        group = "users";
       };
     };
     services."manage-flatpaks-activation" =

--- a/nixos/service.nix
+++ b/nixos/service.nix
@@ -47,7 +47,7 @@ in
 {
   config.systemd = {
     tmpfiles.settings = {
-      "what-do-i-name-this?".rules."${cfg.internal.targetDir}".d = {
+      "flatpak-directory".rules."${cfg.internal.targetDir}".d = {
         mode = "750";
         user = "-";
         group = "-";

--- a/nixos/service.nix
+++ b/nixos/service.nix
@@ -49,9 +49,6 @@ in
     tmpfiles.settings = {
       "flatpak-directory".rules."${cfg.internal.targetDir}".d = {
         mode = "750";
-        user = "-";
-        group = "-";
-        age = "-";
       };
     };
     services."manage-flatpaks-activation" =


### PR DESCRIPTION
Fix issue where `tmpfiles.rules` threw an error when switching/rebuilding (because it was outdated) by instead using `tmpfiles.settings`. 

Uses `"what-do-i-name-this?"` as a placeholder config name. This will get updated later.