### PR TITLE
fix: default nixos/home module outputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -5,11 +5,11 @@
       nixosModule = builtins.warn "declarative-flatpak: flake output `nixosModule` has been renamed to `nixosModules.default`" ./nixos;
       homeModule = builtins.warn "declarative-flatpak: flake output `homeModule` has been renamed to `homeModules.default`" ./home-manager;
       nixosModules = {
-        default = self.outputs.nixosModules.declarative-flatpak;
+        default = self.nixosModules.declarative-flatpak;
         declarative-flatpak = ./nixos;
       };
       homeModules = {
-        default = self.outputs.homeModules.declarative-flatpak;
+        default = self.homeModules.declarative-flatpak;
         declarative-flatpak = ./home-manager;
       };
     };


### PR DESCRIPTION
This PR fixes an evaluation error when trying to import the module using the default output.

The error you got previously:
```
error: attribute 'outputs' missing
       at /nix/store/lwh41l72dqsaxv75wn239ms7vld3r2kg-source/flake.nix:8:19:
            7|       nixosModules = {
            8|         default = self.outputs.nixosModules.declarative-flatpak;
             |                   ^
            9|         declarative-flatpak = ./nixos;
```