### PR TITLE
fix ini type

### DIFF
--- a/lib/types/ini.nix
+++ b/lib/types/ini.nix
@@ -2,6 +2,6 @@
 {
   # Credit: https://github.com/PJungkamp #23 #25
   ini = pkgs.formats.ini {
-    listToValue = lib.concatMapStringsSep ";" (lib.generators.mkValueStringDefault { });
+    listToValue = l: (lib.concatMapStringsSep ";" (lib.generators.mkValueStringDefault { }) l) + ";";
   };
 }


### PR DESCRIPTION
~~CONTRIBUTES: #42~~

~~The problem I had in #42 where~~

```nix
services.flatpak.overrides."org.vinegarhq.Sober".Context.devices = [ "input" ];
```

~~Was failing is due to it requiring a trailing semicolon, such as :~~

```nix
services.flatpak.overrides."org.vinegarhq.Sober".Context.devices = [ "input;" ];
```

~~Because for a single-element list like `[ "input" ]`, the output would simply be `devices=input` and not `devices=input;` which GLib **silently** rejects as an invalid list type, and Flatpak **silently drops the parameter**~~

~~_That was a nightmare to trace_~~

~~This PR fixes this~~

Eventually I found out a clanker wrongfully inputed an invisible unparsable character in the string, it wasn't a problem about the function not enforcing a semicolon. Lost 1.5 hours, nice.